### PR TITLE
Fix typos/grammar and simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,18 @@ CashShuffle is a plugin for the [Electron Cash](https://electroncash.org/) BCH w
 
 ## Installation
 
-Ubuntu users can install using the following command. This command downloads the latest version of Electron Cash and CashShuffle, places CashShuffle in the Electron Cash plugin folder, and re-installs Electron Cash.
+Ubuntu users can install using the following command. This command will install the latest version of Electron Cash with CashShuffle in your home directory.
 
 ```
 cd ~/ && wget https://electroncash.org/downloads/3.0/win-linux/ElectronCash-3.0.tar.gz && tar -xvzf ElectronCash-3.0.tar.gz && rm -rf ElectronCash-3.0.tar.gz && wget https://github.com/cashshuffle/cashshuffle-electron-cash-plugin/archive/master.zip && unzip master.zip && rm -rf master.zip && mv cashshuffle-electron-cash-plugin-master/shuffle 'Electron Cash-3.0/plugins' && rm -rf cashshuffle-electron-cash-plugin-master && sed -i "s/'electroncash_plugins.virtualkeyboard',/'electroncash_plugins.virtualkeyboard', 'electroncash_plugins.shuffle',/" 'Electron Cash-3.0/setup.py' && cd 'Electron Cash-3.0' && sudo python3 setup.py install
 ```
 
-1. place the `shuffle` folder to electron-cash `/plugins` folder
-2. add the link to plugin to electron-cash setup.py with adding `'electroncash_plugins.shuffle'` to setup packages list.
-3. re-install electron-cahs
+Otherwise, use the following instructions:
 
-```
-sudo python3 setup.py install
-```
+1. Place the `shuffle` folder `cashshuffle-electron-cash-plugin-master/shuffle` into the Electron Cash plugins folder `Electron Cash-3.0/plugins`
+2. Open the `setup.py` file `Electron Cash-3.0/setup.py` and find the line that contains the text `'electroncash_plugins.virtualkeyboard'`. Replace this text with `'electroncash_plugins.virtualkeyboard', 'electroncash_plugins.shuffle',`
+3. Change directories into Electron Cash, and re-install `sudo python3 setup.py install`
+
 ## Getting started
 
 1. Enable plugin from 'tools/plugins' menu

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Replace this text with
 
 ## Getting started
 
-1. Enable plugin from 'tools/plugins' menu
+1. Enable the plugin by going to `Tools -> Plugins`
 
 ![Settings](/images/settings.png)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# shuffle
+# Shuffle
 
-This plugin for electron-cash BCH wallet. It allows user to make a coinjoin shuffled transaction.
+This is a plugin for the [Electron Cash](https://electroncash.org/) BCH wallet. It allows users to make shuffled transactions using coinjoin.
 
 ## Installation
 1. place the `shuffle` folder to electron-cash `/plugins` folder

--- a/README.md
+++ b/README.md
@@ -39,22 +39,22 @@ Replace this text with
 
 ![Server settings](/images/shuffle_tab.png)
 
-## Making shuffle
+## Making a shuffle
 
-1. Form `Shuffle input address` choose coin which you want to shuffle. The list of coins formed from utxo's of your wallet.
+1. Use `Shuffle input address` to choose coin which you want to shuffle. This list of coins is formed from  the UTXO's of your wallet.
 
-2. From `Shuffle change address` choose the address for the change. You can leave default setting if you don't want to get any change back.
+2. From `Shuffle change address` choose the address for your change. You can leave this as the default setting if you don't want to get any change back.
 
-3. From `Shuffle output address` choose the address for shuffled output
+3. From `Shuffle output address` choose the address for the shuffled output.
 
-4. In the amount block choose the amount of coins for shuffling.
+4. In the amount block, choose the amount of coins for shuffling.
 
-5. Fee is fixed and unchanged  
+5. Fee is fixed and unchanged.  
 
-6. If amount of coins in input grater then sum of shuffling amount fee then `Shuffle` button will become enabled
+6. If the amount of coins in input is greater than the sum of the shuffling amount fee, then `Shuffle` button will become enabled
 
-7. Pressing the `Shuffle` will start shuffling process. After 5 players registered on server shuffling process will starts.
+7. Pressing `Shuffle` will start the shuffling process. After 5 participants registered on the server, the shuffling process will start.
 
-8. If all goes good you will see the outputs and transaction dialog window in the end. If something goes wrong you will see the errors in output.
+8. If all goes well, you will see the outputs and a transaction dialog window. If something goes wrong you will see the errors in the output.
 
-9. In this version of protocol one of the players should press `broadcast` on transaction dialog window.    
+9. In this version of protocol, one of the participants should press `broadcast` on the transaction dialog window.    

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ cd ~/ && wget https://electroncash.org/downloads/3.0/win-linux/ElectronCash-3.0.
 Otherwise, use the following instructions:
 
 1. Place the `shuffle` folder `cashshuffle-electron-cash-plugin-master/shuffle` into the Electron Cash plugins folder `Electron Cash-3.0/plugins`
-2. Open the `setup.py` file `Electron Cash-3.0/setup.py` and find the line that contains the text `'electroncash_plugins.virtualkeyboard'`. Replace this text with
+2. Open the `setup.py` file `Electron Cash-3.0/setup.py` and find the line that contains the text
+
+```'electroncash_plugins.virtualkeyboard'```
+
+Replace this text with
 
 ```'electroncash_plugins.virtualkeyboard', 'electroncash_plugins.shuffle',```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Replace this text with
 
 ```'electroncash_plugins.virtualkeyboard', 'electroncash_plugins.shuffle',```
 
-3. Change directories into Electron Cash, and re-install `sudo python3 setup.py install`
+3. `cd` into your Electron Cash directory, and re-install
+
+```sudo python3 setup.py install```
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CashShuffle is a plugin for the [Electron Cash](https://electroncash.org/) BCH w
 
 Ubuntu users can install using the following command. This command downloads the latest version of Electron Cash and CashShuffle, places CashShuffle in the Electron Cash plugin folder, and re-installs Electron Cash.
 
-`cd ~/ && wget https://electroncash.org/downloads/3.0/win-linux/ElectronCash-3.0.tar.gz && tar -xvzf ElectronCash-3.0.tar.gz && rm -rf ElectronCash-3.0.tar.gz && wget https://github.com/cashshuffle/cashshuffle-electron-cash-plugin/archive/master.zip && unzip master.zip && rm -rf master.zip && mv cashshuffle-electron-cash-plugin-master/shuffle 'Electron Cash-3.0/plugins' && rm -rf cashshuffle-electron-cash-plugin-master && sed -i "s/'electroncash_plugins.virtualkeyboard',/'electroncash_plugins.virtualkeyboard', 'electroncash_plugins.shuffle',/" 'Electron Cash-3.0/setup.py' && cd 'Electron Cash-3.0' && sudo python3 setup.py install`
+```cd ~/ && wget https://electroncash.org/downloads/3.0/win-linux/ElectronCash-3.0.tar.gz && tar -xvzf ElectronCash-3.0.tar.gz && rm -rf ElectronCash-3.0.tar.gz && wget https://github.com/cashshuffle/cashshuffle-electron-cash-plugin/archive/master.zip && unzip master.zip && rm -rf master.zip && mv cashshuffle-electron-cash-plugin-master/shuffle 'Electron Cash-3.0/plugins' && rm -rf cashshuffle-electron-cash-plugin-master && sed -i "s/'electroncash_plugins.virtualkeyboard',/'electroncash_plugins.virtualkeyboard', 'electroncash_plugins.shuffle',/" 'Electron Cash-3.0/setup.py' && cd 'Electron Cash-3.0' && sudo python3 setup.py install```
 
 1. place the `shuffle` folder to electron-cash `/plugins` folder
 2. add the link to plugin to electron-cash setup.py with adding `'electroncash_plugins.shuffle'` to setup packages list.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ cd ~/ && wget https://electroncash.org/downloads/3.0/win-linux/ElectronCash-3.0.
 Otherwise, use the following instructions:
 
 1. Place the `shuffle` folder `cashshuffle-electron-cash-plugin-master/shuffle` into the Electron Cash plugins folder `Electron Cash-3.0/plugins`
-2. Open the `setup.py` file `Electron Cash-3.0/setup.py` and find the line that contains the text `'electroncash_plugins.virtualkeyboard'`. Replace this text with `'electroncash_plugins.virtualkeyboard', 'electroncash_plugins.shuffle',`
+2. Open the `setup.py` file `Electron Cash-3.0/setup.py` and find the line that contains the text `'electroncash_plugins.virtualkeyboard'`. Replace this text with
+
+```'electroncash_plugins.virtualkeyboard', 'electroncash_plugins.shuffle',```
+
 3. Change directories into Electron Cash, and re-install `sudo python3 setup.py install`
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Replace this text with
 
 6. If the amount of coins in input is greater than the sum of the shuffling amount fee, then the `Shuffle` button will become enabled
 
-7. Pressing `Shuffle` will start the shuffling process. After 5 participants registered on the server, the shuffling process will start.
+7. Pressing `Shuffle` will start the shuffling process. After 5 participants registered on the server, the shuffling process will begin.
 
 8. If all goes well, you will see the outputs and a transaction dialog window. If something goes wrong you will see the errors in the output.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Replace this text with
 
 5. Fee is fixed and unchanged.  
 
-6. If the amount of coins in input is greater than the sum of the shuffling amount fee, then `Shuffle` button will become enabled
+6. If the amount of coins in input is greater than the sum of the shuffling amount fee, then the `Shuffle` button will become enabled
 
 7. Pressing `Shuffle` will start the shuffling process. After 5 participants registered on the server, the shuffling process will start.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Shuffle
 
-This is a plugin for the [Electron Cash](https://electroncash.org/) BCH wallet. It allows users to make shuffled transactions using coinjoin.
+CashShuffle is a plugin for the [Electron Cash](https://electroncash.org/) BCH wallet. It allows users to make shuffled transactions using [CoinJoin](https://en.wikipedia.org/wiki/CoinJoin).
 
 ## Installation
+
+Ubuntu users can install using the following command. This command downloads the latest version of Electron Cash and CashShuffle, places CashShuffle in the Electron Cash plugin folder, and re-installs Electron Cash.
+
+`cd ~/ && wget https://electroncash.org/downloads/3.0/win-linux/ElectronCash-3.0.tar.gz && tar -xvzf ElectronCash-3.0.tar.gz && rm -rf ElectronCash-3.0.tar.gz && wget https://github.com/cashshuffle/cashshuffle-electron-cash-plugin/archive/master.zip && unzip master.zip && rm -rf master.zip && mv cashshuffle-electron-cash-plugin-master/shuffle 'Electron Cash-3.0/plugins' && rm -rf cashshuffle-electron-cash-plugin-master && sed -i "s/'electroncash_plugins.virtualkeyboard',/'electroncash_plugins.virtualkeyboard', 'electroncash_plugins.shuffle',/" 'Electron Cash-3.0/setup.py' && cd 'Electron Cash-3.0' && sudo python3 setup.py install`
+
 1. place the `shuffle` folder to electron-cash `/plugins` folder
 2. add the link to plugin to electron-cash setup.py with adding `'electroncash_plugins.shuffle'` to setup packages list.
 3. re-install electron-cahs

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ CashShuffle is a plugin for the [Electron Cash](https://electroncash.org/) BCH w
 
 Ubuntu users can install using the following command. This command downloads the latest version of Electron Cash and CashShuffle, places CashShuffle in the Electron Cash plugin folder, and re-installs Electron Cash.
 
-```cd ~/ && wget https://electroncash.org/downloads/3.0/win-linux/ElectronCash-3.0.tar.gz && tar -xvzf ElectronCash-3.0.tar.gz && rm -rf ElectronCash-3.0.tar.gz && wget https://github.com/cashshuffle/cashshuffle-electron-cash-plugin/archive/master.zip && unzip master.zip && rm -rf master.zip && mv cashshuffle-electron-cash-plugin-master/shuffle 'Electron Cash-3.0/plugins' && rm -rf cashshuffle-electron-cash-plugin-master && sed -i "s/'electroncash_plugins.virtualkeyboard',/'electroncash_plugins.virtualkeyboard', 'electroncash_plugins.shuffle',/" 'Electron Cash-3.0/setup.py' && cd 'Electron Cash-3.0' && sudo python3 setup.py install```
+```
+cd ~/ && wget https://electroncash.org/downloads/3.0/win-linux/ElectronCash-3.0.tar.gz && tar -xvzf ElectronCash-3.0.tar.gz && rm -rf ElectronCash-3.0.tar.gz && wget https://github.com/cashshuffle/cashshuffle-electron-cash-plugin/archive/master.zip && unzip master.zip && rm -rf master.zip && mv cashshuffle-electron-cash-plugin-master/shuffle 'Electron Cash-3.0/plugins' && rm -rf cashshuffle-electron-cash-plugin-master && sed -i "s/'electroncash_plugins.virtualkeyboard',/'electroncash_plugins.virtualkeyboard', 'electroncash_plugins.shuffle',/" 'Electron Cash-3.0/setup.py' && cd 'Electron Cash-3.0' && sudo python3 setup.py install
+```
 
 1. place the `shuffle` folder to electron-cash `/plugins` folder
 2. add the link to plugin to electron-cash setup.py with adding `'electroncash_plugins.shuffle'` to setup packages list.


### PR DESCRIPTION
I have fixed some typos/grammar issues, and made the page look cleaner.

I have added a command to simplify the installation of CashShuffle on Ubuntu. In the home directory, this command downloads the latest version of Electron Cash and also downloads the latest version of CashShuffle. It then places the "shuffle" folder into the Electron Cash "plugins" folder. Then "setup.py" is edited to add a line for the CashShuffle plugin. Electron Cash is then installed.