### PR TITLE
Fixed index out-of-range for newly generated wallets

### DIFF
--- a/shuffle/shuffle.py
+++ b/shuffle/shuffle.py
@@ -108,7 +108,10 @@ class InputAdressWidget(QComboBox):
             return None
 
     def get_input_address_as_string(self, fmt=Address.FMT_LEGACY):
-        return self.inputsArray[self.currentIndex()]['address'].to_string(fmt)
+        if len(self.inputsArray) > 0:
+            return self.inputsArray[self.currentIndex()]['address'].to_string(fmt)
+        else:
+            return None
 
     def get_input_value(self):
         i = self.currentIndex()


### PR DESCRIPTION
Tried cashshuffle on a brand new wallet to find that shuffle would constantly crash until initial funds were confirmed.  Tested manually to confirm the fix (there's no test coverage for this portion of code by the looks of it)