### PR TITLE
deprecate and redirect to cashshuffle / electron repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # DEPRECATED
 
-CashShuffle has been merged into [Electron Cash](https://github.com/Electron-Cash/Electron-Cash/).  
+This repository is archived and will not be maintained.
+
+You can find CashShuffle documentation at [github.com/cashshuffle/spec](https://github.com/cashshuffle/spec).
+
+CashShuffle plugin has been merged into [Electron Cash](https://github.com/Electron-Cash/Electron-Cash/).  


### PR DESCRIPTION
@fyookball

If this is fine, could you merge it and then [archive the repo](https://github.blog/2017-11-08-archiving-repositories/), which will put it in read-only mode?